### PR TITLE
Feat/4 판매글 등록 API 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       MARKET_DB_NAME: pagely_market
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
+      GPR_USER: ${{ secrets.GPR_USER }}
+      GPR_KEY: ${{ secrets.GPR_KEY }}
 
     steps:
       - name: Checkout source code

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,13 @@ java {
 
 repositories {
     mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.github.com/Pagely-wisely/common")
+        credentials {
+            username = findProperty("gpr.user")
+            password = findProperty("gpr.key")
+        }
+    }
 }
 
 ext {
@@ -22,6 +29,9 @@ ext {
 }
 
 dependencies {
+    //공통 라이브러리
+    implementation 'com.pagely:common:1.0.2'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -33,6 +43,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     implementation 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ repositories {
     maven {
         url = uri("https://maven.pkg.github.com/Pagely-wisely/common")
         credentials {
-            username = findProperty("gpr.user")
-            password = findProperty("gpr.key")
+            username = findProperty("gpr.user") ?: System.getenv("GPR_USER")
+            password = findProperty("gpr.key") ?: System.getenv("GPR_KEY")
         }
     }
 }

--- a/src/main/java/com/pagely/marketservice/MarketserviceApplication.java
+++ b/src/main/java/com/pagely/marketservice/MarketserviceApplication.java
@@ -2,8 +2,9 @@ package com.pagely.marketservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
-//@EnableFeignClients
+@EnableFeignClients
 @SpringBootApplication
 public class MarketserviceApplication {
 

--- a/src/main/java/com/pagely/marketservice/application/dto/command/CreateSalePostCommand.java
+++ b/src/main/java/com/pagely/marketservice/application/dto/command/CreateSalePostCommand.java
@@ -1,0 +1,13 @@
+package com.pagely.marketservice.application.dto.command;
+
+import java.util.UUID;
+
+public record CreateSalePostCommand(
+        UUID sellerId,
+        String bookId,
+        String title,
+        String description,
+        int price,
+        String condition
+) {
+}

--- a/src/main/java/com/pagely/marketservice/application/dto/result/SalePostResult.java
+++ b/src/main/java/com/pagely/marketservice/application/dto/result/SalePostResult.java
@@ -1,0 +1,38 @@
+package com.pagely.marketservice.application.dto.result;
+
+import com.pagely.marketservice.domain.model.SalePost;
+import com.pagely.marketservice.domain.model.SalePostStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record SalePostResult(
+        UUID id,                // 판매글ID
+        UUID sellerId,          // 판매자ID
+        String bookId,          // 판매도서ID
+        String title,           // 판매글 제목
+        String description,     // 판매글 상세 설명
+        int price,              // 판매 가격
+        SalePostStatus status,  // 판매글 상태
+        String condition,       // 상품 상태
+        LocalDateTime createdAt,// 생성 일시
+        UUID createdBy,         // 생성자ID
+        LocalDateTime updatedAt,// 수정 일시
+        UUID updatedBy          // 수정자ID
+) {
+    public static SalePostResult fromEntity(SalePost salePost) {
+        return new SalePostResult(
+                salePost.getId(),
+                salePost.getSellerId(),
+                salePost.getBookId(),
+                salePost.getTitle(),
+                salePost.getDescription(),
+                salePost.getPrice(),
+                salePost.getStatus(),
+                salePost.getCondition(),
+                salePost.getCreatedAt(),
+                salePost.getCreatedBy(),
+                salePost.getUpdatedAt(),
+                salePost.getUpdatedBy()
+        );
+    }
+}

--- a/src/main/java/com/pagely/marketservice/application/service/SalePostService.java
+++ b/src/main/java/com/pagely/marketservice/application/service/SalePostService.java
@@ -1,0 +1,31 @@
+package com.pagely.marketservice.application.service;
+
+import com.pagely.marketservice.application.dto.command.CreateSalePostCommand;
+import com.pagely.marketservice.application.dto.result.SalePostResult;
+import com.pagely.marketservice.domain.model.SalePost;
+import com.pagely.marketservice.domain.repository.SalePostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SalePostService {
+
+    private final SalePostRepository salePostRepository;
+
+    public SalePostResult createSalePost(CreateSalePostCommand command) {
+        SalePost salePost = SalePost.create(
+                command.sellerId(),
+                command.bookId(),
+                command.title(),
+                command.description(),
+                command.price(),
+                command.condition()
+        );
+        salePostRepository.save(salePost);
+
+        return SalePostResult.fromEntity(salePost);
+    }
+}

--- a/src/main/java/com/pagely/marketservice/application/service/SalePostService.java
+++ b/src/main/java/com/pagely/marketservice/application/service/SalePostService.java
@@ -15,6 +15,7 @@ public class SalePostService {
 
     private final SalePostRepository salePostRepository;
 
+    @Transactional
     public SalePostResult createSalePost(CreateSalePostCommand command) {
         SalePost salePost = SalePost.create(
                 command.sellerId(),

--- a/src/main/java/com/pagely/marketservice/application/service/SalePostService.java
+++ b/src/main/java/com/pagely/marketservice/application/service/SalePostService.java
@@ -25,8 +25,8 @@ public class SalePostService {
                 command.price(),
                 command.condition()
         );
-        salePostRepository.save(salePost);
+        SalePost saved = salePostRepository.save(salePost);
 
-        return SalePostResult.fromEntity(salePost);
+        return SalePostResult.fromEntity(saved);
     }
 }

--- a/src/main/java/com/pagely/marketservice/domain/model/SalePost.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/SalePost.java
@@ -1,5 +1,6 @@
 package com.pagely.marketservice.domain.model;
 
+import com.pagely.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -8,7 +9,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "p_sale_post")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SalePost {
+public class SalePost extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -43,7 +43,7 @@ public class SalePost {
 
     // 판매 가격
     @Column(nullable = false)
-    private Integer price;
+    private int price;
 
     // 판매글 상태
     @Enumerated(EnumType.STRING)
@@ -54,23 +54,27 @@ public class SalePost {
     @Column(nullable = false, length = 20)
     private String condition;
 
-    // 공통 감사 컬럼
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    public static SalePost create(
+            UUID sellerId,
+            String bookId,
+            String title,
+            String description,
+            int price,
+            String condition
+    ) {
+        if (price <= 0) {
+            throw new IllegalArgumentException("판매 가격은 0보다 커야합니다.");
+        }
 
-    @Column(name = "created_by", nullable = false, columnDefinition = "uuid")
-    private UUID createdBy;
+        SalePost salePost = new SalePost();
+        salePost.sellerId = sellerId;
+        salePost.bookId = bookId;
+        salePost.title = title;
+        salePost.description = description;
+        salePost.price = price;
+        salePost.condition = condition;
+        salePost.status = SalePostStatus.AVAILABLE;
 
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    @Column(name = "updated_by", columnDefinition = "uuid")
-    private UUID updatedBy;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
-    @Column(name = "deleted_by", columnDefinition = "uuid")
-    private UUID deletedBy;
-
+        return salePost;
+    }
 }

--- a/src/main/java/com/pagely/marketservice/domain/repository/SalePostRepository.java
+++ b/src/main/java/com/pagely/marketservice/domain/repository/SalePostRepository.java
@@ -1,0 +1,7 @@
+package com.pagely.marketservice.domain.repository;
+
+import com.pagely.marketservice.domain.model.SalePost;
+
+public interface SalePostRepository {
+    SalePost save(SalePost salePost);
+}

--- a/src/main/java/com/pagely/marketservice/infrastructure/config/JpaAuditingConfig.java
+++ b/src/main/java/com/pagely/marketservice/infrastructure/config/JpaAuditingConfig.java
@@ -1,0 +1,19 @@
+package com.pagely.marketservice.infrastructure.config;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorAware")
+public class JpaAuditingConfig {
+
+    @Bean
+    public AuditorAware<UUID> auditorAware() {
+        // TODO: 임시로 구현
+        return () -> Optional.of(UUID.fromString("00000000-0000-0000-0000-000000000000"));
+    }
+}

--- a/src/main/java/com/pagely/marketservice/infrastructure/persistence/JpaSalePostRepository.java
+++ b/src/main/java/com/pagely/marketservice/infrastructure/persistence/JpaSalePostRepository.java
@@ -1,0 +1,8 @@
+package com.pagely.marketservice.infrastructure.persistence;
+
+import com.pagely.marketservice.domain.model.SalePost;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaSalePostRepository extends JpaRepository<SalePost, UUID> {
+}

--- a/src/main/java/com/pagely/marketservice/infrastructure/persistence/SalePostRepositoryAdapter.java
+++ b/src/main/java/com/pagely/marketservice/infrastructure/persistence/SalePostRepositoryAdapter.java
@@ -1,0 +1,18 @@
+package com.pagely.marketservice.infrastructure.persistence;
+
+import com.pagely.marketservice.domain.model.SalePost;
+import com.pagely.marketservice.domain.repository.SalePostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SalePostRepositoryAdapter implements SalePostRepository {
+
+    private final JpaSalePostRepository jpaSalePostRepository;
+
+    @Override
+    public SalePost save(SalePost salePost) {
+        return jpaSalePostRepository.save(salePost);
+    }
+}

--- a/src/main/java/com/pagely/marketservice/presentation/controller/SalePostController.java
+++ b/src/main/java/com/pagely/marketservice/presentation/controller/SalePostController.java
@@ -1,0 +1,36 @@
+package com.pagely.marketservice.presentation.controller;
+
+import com.pagely.common.response.ApiResponse;
+import com.pagely.marketservice.application.dto.command.CreateSalePostCommand;
+import com.pagely.marketservice.application.dto.result.SalePostResult;
+import com.pagely.marketservice.application.service.SalePostService;
+import com.pagely.marketservice.presentation.dto.request.CreateSalePostRequest;
+import com.pagely.marketservice.presentation.dto.response.CreateSalePostResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/sale-posts")
+public class SalePostController {
+
+    private final SalePostService salePostService;
+
+    @PostMapping()
+    public ResponseEntity<ApiResponse> createSalePost(
+            @RequestHeader("X-User-Id") UUID sellerId,
+            @Valid @RequestBody CreateSalePostRequest request
+    ) {
+        CreateSalePostCommand command = request.toCommand(sellerId);
+        SalePostResult result = salePostService.createSalePost(command);
+        CreateSalePostResponse response = CreateSalePostResponse.fromResult(result);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/com/pagely/marketservice/presentation/dto/request/CreateSalePostRequest.java
+++ b/src/main/java/com/pagely/marketservice/presentation/dto/request/CreateSalePostRequest.java
@@ -1,0 +1,39 @@
+package com.pagely.marketservice.presentation.dto.request;
+
+import com.pagely.marketservice.application.dto.command.CreateSalePostCommand;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record CreateSalePostRequest(
+        @NotBlank(message = "bookId는 필수입니다.")
+        String bookId,
+
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 100, message = "제목은 100자 이하여야 합니다.")
+        String title,
+
+        @NotBlank(message = "설명은 필수입니다.")
+        String description,
+
+        @Min(value = 1, message = "가격은 1원 이상이어야 합니다.")
+        @Max(value = 10_000_000, message = "가격은 1000만원 이하여야 합니다.")
+        int price,
+
+        @NotBlank(message = "도서 상태는 필수입니다.")
+        @Size(max = 20, message = "도서 상태는 20자 이하여야 합니다.")
+        String condition
+) {
+    public CreateSalePostCommand toCommand(UUID sellerId) {
+        return new CreateSalePostCommand(
+                sellerId,
+                this.bookId(),
+                this.title(),
+                this.description(),
+                this.price(),
+                this.condition()
+        );
+    }
+}

--- a/src/main/java/com/pagely/marketservice/presentation/dto/response/CreateSalePostResponse.java
+++ b/src/main/java/com/pagely/marketservice/presentation/dto/response/CreateSalePostResponse.java
@@ -1,0 +1,34 @@
+package com.pagely.marketservice.presentation.dto.response;
+
+import com.pagely.marketservice.application.dto.result.SalePostResult;
+import com.pagely.marketservice.domain.model.SalePostStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CreateSalePostResponse(
+        UUID id,                // 판매글ID
+        UUID sellerId,          // 판매자ID
+        String bookId,          // 판매도서ID
+        String title,           // 판매글 제목
+        String description,     // 판매글 상세 설명
+        int price,              // 판매 가격
+        SalePostStatus status,  // 판매글 상태
+        String condition,       // 상품 상태
+        LocalDateTime createdAt,// 생성 일시
+        UUID createdBy          // 생성자ID
+) {
+    public static CreateSalePostResponse fromResult(SalePostResult result) {
+        return new CreateSalePostResponse(
+                result.id(),
+                result.sellerId(),
+                result.bookId(),
+                result.title(),
+                result.description(),
+                result.price(),
+                result.status(),
+                result.condition(),
+                result.createdAt(),
+                result.createdBy()
+        );
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 판매글 등록 API 구현
- 공통 모듈 연동
- JpaAuditConfig 임시 설정

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #5
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #4 

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="797" height="582" alt="image" src="https://github.com/user-attachments/assets/24c8f79f-98c1-4990-a7e9-f0ad84136337" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 판매 게시물 생성 API 추가 — POST /api/v1/sale-posts로 게시물 생성 지원  
  * 요청 유효성 검증 강화(필수 필드, 길이, 가격 범위 등)  
  * 생성 응답에 ID·판매자/도서 정보·제목·설명·가격·상태·상품 상태·생성일시·생성자 포함  

* **개선**
  * 게시물 생성 시 가격 유효성(0보다 큼) 검증 적용  

* **작업(Chore)**
  * 빌드 및 배포 설정 업데이트(인증/의존성 구성 수정)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->