### PR TITLE
Feat/16 운송장 번호 등록 (판매자) API 구현

### DIFF
--- a/src/main/java/com/pagely/marketservice/application/dto/command/RegisterTrackingNumberCommand.java
+++ b/src/main/java/com/pagely/marketservice/application/dto/command/RegisterTrackingNumberCommand.java
@@ -1,0 +1,11 @@
+package com.pagely.marketservice.application.dto.command;
+
+import java.util.UUID;
+
+public record RegisterTrackingNumberCommand(
+        UUID sellerId,
+        UUID orderId,
+        String trackingNumber,
+        String courierCompany
+) {
+}

--- a/src/main/java/com/pagely/marketservice/application/service/OrderService.java
+++ b/src/main/java/com/pagely/marketservice/application/service/OrderService.java
@@ -2,6 +2,7 @@ package com.pagely.marketservice.application.service;
 
 import com.pagely.common.exception.BusinessException;
 import com.pagely.marketservice.application.dto.command.CreateOrderCommand;
+import com.pagely.marketservice.application.dto.command.RegisterTrackingNumberCommand;
 import com.pagely.marketservice.application.dto.result.OrderResult;
 import com.pagely.marketservice.domain.exception.OrderErrorCode;
 import com.pagely.marketservice.domain.exception.SalePostErrorCode;
@@ -42,6 +43,21 @@ public class OrderService {
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
         order.validateOwner(buyerId); // 구매자의 주문인지 검증
+
+        return OrderResult.fromEntity(order);
+    }
+
+    // 판매자가 운송장 번호 등록
+    @Transactional
+    public OrderResult registerTrackingNumber(RegisterTrackingNumberCommand command) {
+        // 주문 조회
+        Order order = orderRepository.findByIdWithSalePost(command.orderId())
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+        // 주문의 판매자인지 검증
+        order.validateSeller(command.sellerId());
+
+        // 운송장 번호 등록
+        order.registerTrackingNumber(command.trackingNumber(), command.courierCompany());
 
         return OrderResult.fromEntity(order);
     }

--- a/src/main/java/com/pagely/marketservice/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/pagely/marketservice/domain/exception/OrderErrorCode.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum OrderErrorCode implements ErrorCode {
     NOT_ORDER_OWNER("본인의 주문만 조회할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ORDER_SELLER_MISMATCH("해당 주문의 판매자가 아닙니다.", HttpStatus.FORBIDDEN),
+    ORDER_STATUS_NOT_ACCEPTED("주문 승인 상태에서만 가능합니다.", HttpStatus.BAD_REQUEST),
     ORDER_NOT_FOUND("해당 주문을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;

--- a/src/main/java/com/pagely/marketservice/domain/model/Order.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/Order.java
@@ -90,4 +90,26 @@ public class Order extends BaseEntity {
             throw new BusinessException(OrderErrorCode.NOT_ORDER_OWNER);
         }
     }
+
+    // 해당 주문의 판매자인지 검증
+    public void validateSeller(UUID sellerId) {
+        SalePost salePost = this.getSalePost();
+
+        if (salePost != null && !salePost.isSeller(sellerId)) {
+            throw new BusinessException(OrderErrorCode.ORDER_SELLER_MISMATCH);
+        }
+    }
+
+    // 운송장 번호 / 택배사 정보 등록
+    public void registerTrackingNumber(String trackingNumber, String courierCompany) {
+        // 주문 승인(ACCEPTED) 상태에서만 운송장 정보 등록 가능
+        if (this.status != OrderStatus.ACCEPTED) {
+            throw new BusinessException(OrderErrorCode.ORDER_STATUS_NOT_ACCEPTED);
+        }
+
+        this.trackingNumber = trackingNumber;
+        this.courierCompany = courierCompany;
+        this.trackingRegisteredAt = LocalDateTime.now();
+        this.status = OrderStatus.SHIPPING;
+    }
 }

--- a/src/main/java/com/pagely/marketservice/domain/model/Order.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/Order.java
@@ -93,9 +93,7 @@ public class Order extends BaseEntity {
 
     // 해당 주문의 판매자인지 검증
     public void validateSeller(UUID sellerId) {
-        SalePost salePost = this.getSalePost();
-
-        if (salePost != null && !salePost.isSeller(sellerId)) {
+        if (!this.getSalePost().isSeller(sellerId)) {
             throw new BusinessException(OrderErrorCode.ORDER_SELLER_MISMATCH);
         }
     }

--- a/src/main/java/com/pagely/marketservice/domain/model/SalePost.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/SalePost.java
@@ -99,13 +99,11 @@ public class SalePost extends BaseEntity {
         this.status = SalePostStatus.RESERVED;
     }
 
+    public boolean isSeller(UUID userId) {
+        return this.sellerId.equals(userId);
+    }
+
     private boolean isAvailable() {
         return this.status == SalePostStatus.AVAILABLE;
     }
-
-    private boolean isSeller(UUID buyerId) {
-        return this.sellerId.equals(buyerId);
-    }
-
-
 }

--- a/src/main/java/com/pagely/marketservice/domain/repository/OrderRepository.java
+++ b/src/main/java/com/pagely/marketservice/domain/repository/OrderRepository.java
@@ -8,4 +8,6 @@ public interface OrderRepository {
     Order save(Order order);
 
     Optional<Order> findById(UUID orderId);
+
+    Optional<Order> findByIdWithSalePost(UUID orderID);
 }

--- a/src/main/java/com/pagely/marketservice/infrastructure/persistence/JpaOrderRepository.java
+++ b/src/main/java/com/pagely/marketservice/infrastructure/persistence/JpaOrderRepository.java
@@ -1,8 +1,19 @@
 package com.pagely.marketservice.infrastructure.persistence;
 
 import com.pagely.marketservice.domain.model.Order;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaOrderRepository extends JpaRepository<Order, UUID> {
+
+    @Query("""
+            	select o from Order o
+            	left join fetch o.salePost sp
+            	where o.id = :orderId
+            	and o.deletedAt is null
+            """)
+    Optional<Order> findByIdWithSalePost(@Param("orderId") UUID orderId);
 }

--- a/src/main/java/com/pagely/marketservice/infrastructure/persistence/OrderRepositoryAdapter.java
+++ b/src/main/java/com/pagely/marketservice/infrastructure/persistence/OrderRepositoryAdapter.java
@@ -22,4 +22,9 @@ public class OrderRepositoryAdapter implements OrderRepository {
     public Optional<Order> findById(UUID orderId) {
         return jpaOrderRepository.findById(orderId);
     }
+
+    @Override
+    public Optional<Order> findByIdWithSalePost(UUID orderId) {
+        return jpaOrderRepository.findByIdWithSalePost(orderId);
+    }
 }

--- a/src/main/java/com/pagely/marketservice/presentation/controller/OrderController.java
+++ b/src/main/java/com/pagely/marketservice/presentation/controller/OrderController.java
@@ -4,8 +4,10 @@ import com.pagely.common.response.ApiResponse;
 import com.pagely.marketservice.application.dto.result.OrderResult;
 import com.pagely.marketservice.application.service.OrderService;
 import com.pagely.marketservice.presentation.dto.request.CreateOrderRequest;
+import com.pagely.marketservice.presentation.dto.request.RegisterTrackingNumberRequest;
 import com.pagely.marketservice.presentation.dto.response.CreateOrderResponse;
 import com.pagely.marketservice.presentation.dto.response.OrderResponse;
+import com.pagely.marketservice.presentation.dto.response.RegisterTrackingNumberResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -41,5 +43,15 @@ public class OrderController {
     ) {
         OrderResult result = orderService.getOrder(buyerId, orderId);
         return ApiResponse.ok(OrderResponse.fromResult(result));
+    }
+
+    @PostMapping("/{orderId}/tracking")
+    public ResponseEntity<ApiResponse> registerTrackingNumber(
+            @RequestHeader("X-User-Id") UUID sellerId,
+            @PathVariable("orderId") UUID orderId,
+            @Valid @RequestBody RegisterTrackingNumberRequest request
+    ) {
+        OrderResult result = orderService.registerTrackingNumber(request.toCommand(sellerId, orderId));
+        return ApiResponse.ok(RegisterTrackingNumberResponse.fromResult(result));
     }
 }

--- a/src/main/java/com/pagely/marketservice/presentation/dto/request/RegisterTrackingNumberRequest.java
+++ b/src/main/java/com/pagely/marketservice/presentation/dto/request/RegisterTrackingNumberRequest.java
@@ -1,0 +1,25 @@
+package com.pagely.marketservice.presentation.dto.request;
+
+import com.pagely.marketservice.application.dto.command.RegisterTrackingNumberCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record RegisterTrackingNumberRequest(
+        @NotBlank(message = "운송장 번호는 필수입니다.")
+        @Size(max = 50, message = "운송장 번호는 50자 이하여야 합니다.")
+        String trackingNumber,
+
+        @NotBlank(message = "택배사는 필수입니다.")
+        @Size(max = 30, message = "택배사는 30자 이하여야 합니다.")
+        String courierCompany
+) {
+    public RegisterTrackingNumberCommand toCommand(UUID sellerId, UUID orderId) {
+        return new RegisterTrackingNumberCommand(
+                sellerId,
+                orderId,
+                this.trackingNumber,
+                this.courierCompany
+        );
+    }
+}

--- a/src/main/java/com/pagely/marketservice/presentation/dto/response/RegisterTrackingNumberResponse.java
+++ b/src/main/java/com/pagely/marketservice/presentation/dto/response/RegisterTrackingNumberResponse.java
@@ -1,0 +1,28 @@
+package com.pagely.marketservice.presentation.dto.response;
+
+import com.pagely.marketservice.application.dto.result.OrderResult;
+import com.pagely.marketservice.domain.model.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record RegisterTrackingNumberResponse(
+        UUID id,                            // 주문 ID
+        UUID buyerId,                       // 구매자 ID
+        UUID salePostId,                    // 판매글 ID
+        OrderStatus status,                 // 주문 상태
+        String trackingNumber,              // 운송장 번호
+        String courierCompany,              // 택배사
+        LocalDateTime trackingRegisteredAt  // 운송장 등록 일시
+) {
+    public static RegisterTrackingNumberResponse fromResult(OrderResult r) {
+        return new RegisterTrackingNumberResponse(
+                r.id(),
+                r.buyerId(),
+                r.salePostId(),
+                r.status(),
+                r.trackingNumber(),
+                r.courierCompany(),
+                r.trackingRegisteredAt()
+        );
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- #16 
- 운송장 번호 등록 (판매자) API 구현
- 판매자가 `운송장 번호`, `택배사명` 정보 입력

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #16 \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #13

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="814" height="482" alt="image" src="https://github.com/user-attachments/assets/55e1c02e-37fe-4777-94fe-302d6726076d" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 판매자가 주문에 대해 배송 추적번호와 택배사 정보를 등록하는 기능이 추가되었습니다.
  * 등록 후 주문 상태가 자동으로 "배송 중"으로 변경됩니다.
  * 판매자만 등록할 수 있도록 권한 검증이 강화되었습니다.
  * 등록 시 추적번호·택배사 입력에 대한 유효성 검사가 적용되며, 등록 결과(추적정보·등록시각 포함)를 반환합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->