### PR TITLE
Feat/17 구매 확정 (구매자) API 구현

### DIFF
--- a/src/main/java/com/pagely/marketservice/application/dto/result/OrderResult.java
+++ b/src/main/java/com/pagely/marketservice/application/dto/result/OrderResult.java
@@ -15,9 +15,7 @@ public record OrderResult(
         String courierCompany,              // 택배사
         LocalDateTime trackingRegisteredAt, // 운송장 등록 일시
         LocalDateTime createdAt,            // 생성 시각
-        UUID createdBy,                     // 생성자
-        LocalDateTime updatedAt,            // 수정 시각
-        UUID updatedBy                      // 수정자
+        LocalDateTime updatedAt             // 수정 시각
 ) {
     public static OrderResult fromEntity(Order o) {
         return new OrderResult(
@@ -30,9 +28,7 @@ public record OrderResult(
                 o.getCourierCompany(),
                 o.getTrackingRegisteredAt(),
                 o.getCreatedAt(),
-                o.getCreatedBy(),
-                o.getUpdatedAt(),
-                o.getUpdatedBy()
+                o.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/pagely/marketservice/application/service/OrderService.java
+++ b/src/main/java/com/pagely/marketservice/application/service/OrderService.java
@@ -61,4 +61,19 @@ public class OrderService {
 
         return OrderResult.fromEntity(order);
     }
+
+    // 구매자 구매 확정
+    @Transactional
+    public OrderResult confirmOrder(UUID buyerId, UUID orderId) {
+        // 주문 조회
+        Order order = orderRepository.findByIdWithSalePost(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+        // 구매자인지 검증
+        order.validateBuyer(buyerId);
+
+        // 구매 확정
+        order.confirm();
+
+        return OrderResult.fromEntity(order);
+    }
 }

--- a/src/main/java/com/pagely/marketservice/application/service/OrderService.java
+++ b/src/main/java/com/pagely/marketservice/application/service/OrderService.java
@@ -42,7 +42,7 @@ public class OrderService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
-        order.validateOwner(buyerId); // 구매자의 주문인지 검증
+        order.validateBuyer(buyerId); // 구매자의 주문인지 검증
 
         return OrderResult.fromEntity(order);
     }

--- a/src/main/java/com/pagely/marketservice/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/pagely/marketservice/domain/exception/OrderErrorCode.java
@@ -4,7 +4,7 @@ import com.pagely.common.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum OrderErrorCode implements ErrorCode {
-    NOT_ORDER_OWNER("본인의 주문만 조회할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ORDER_BUYER_MISMATCH("본인의 주문만 조회할 수 있습니다.", HttpStatus.FORBIDDEN),
     ORDER_SELLER_MISMATCH("해당 주문의 판매자가 아닙니다.", HttpStatus.FORBIDDEN),
     ORDER_STATUS_NOT_ACCEPTED("주문 승인 상태에서만 가능합니다.", HttpStatus.BAD_REQUEST),
     ORDER_NOT_FOUND("해당 주문을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);

--- a/src/main/java/com/pagely/marketservice/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/pagely/marketservice/domain/exception/OrderErrorCode.java
@@ -4,7 +4,7 @@ import com.pagely.common.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum OrderErrorCode implements ErrorCode {
-    ORDER_BUYER_MISMATCH("본인의 주문만 조회할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ORDER_BUYER_MISMATCH("본인의 주문만 처리할 수 있습니다.", HttpStatus.FORBIDDEN),
     ORDER_SELLER_MISMATCH("해당 주문의 판매자가 아닙니다.", HttpStatus.FORBIDDEN),
     ORDER_STATUS_NOT_ACCEPTED("주문 승인 상태에서만 가능합니다.", HttpStatus.BAD_REQUEST),
     ORDER_STATUS_NOT_SHIPPING("주문 배송 상태에서만 가능합니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/pagely/marketservice/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/pagely/marketservice/domain/exception/OrderErrorCode.java
@@ -7,6 +7,7 @@ public enum OrderErrorCode implements ErrorCode {
     ORDER_BUYER_MISMATCH("본인의 주문만 조회할 수 있습니다.", HttpStatus.FORBIDDEN),
     ORDER_SELLER_MISMATCH("해당 주문의 판매자가 아닙니다.", HttpStatus.FORBIDDEN),
     ORDER_STATUS_NOT_ACCEPTED("주문 승인 상태에서만 가능합니다.", HttpStatus.BAD_REQUEST),
+    ORDER_STATUS_NOT_SHIPPING("주문 배송 상태에서만 가능합니다.", HttpStatus.BAD_REQUEST),
     ORDER_NOT_FOUND("해당 주문을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;

--- a/src/main/java/com/pagely/marketservice/domain/model/Order.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/Order.java
@@ -110,4 +110,18 @@ public class Order extends BaseEntity {
         this.trackingRegisteredAt = LocalDateTime.now();
         this.status = OrderStatus.SHIPPING;
     }
+
+    // 구매 확정 (구매자)
+    public void confirm() {
+        // 상태값
+        if (this.status != OrderStatus.SHIPPING) {
+            throw new BusinessException(OrderErrorCode.ORDER_STATUS_NOT_SHIPPING);
+        }
+
+        // 상태변경
+        this.status = OrderStatus.COMPLETED;
+
+        // 주문 이력 생성
+        OrderHistory.of(this, OrderStatus.SHIPPING, "구매 확정");
+    }
 }

--- a/src/main/java/com/pagely/marketservice/domain/model/Order.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/Order.java
@@ -112,7 +112,7 @@ public class Order extends BaseEntity {
         this.status = OrderStatus.SHIPPING;
 
         // 주문 이력 생성
-        this.histories.add(OrderHistory.of(this, prevStatus, "구매 확정"));
+        this.histories.add(OrderHistory.of(this, prevStatus, "운송장 등록"));
     }
 
     // 구매 확정 (구매자)

--- a/src/main/java/com/pagely/marketservice/domain/model/Order.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/Order.java
@@ -122,6 +122,6 @@ public class Order extends BaseEntity {
         this.status = OrderStatus.COMPLETED;
 
         // 주문 이력 생성
-        OrderHistory.of(this, OrderStatus.SHIPPING, "구매 확정");
+        this.histories.add(OrderHistory.of(this, OrderStatus.SHIPPING, "구매 확정"));
     }
 }

--- a/src/main/java/com/pagely/marketservice/domain/model/Order.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/Order.java
@@ -85,9 +85,9 @@ public class Order extends BaseEntity {
         return order;
     }
 
-    public void validateOwner(UUID buyerId) {
+    public void validateBuyer(UUID buyerId) {
         if (!this.buyerId.equals(buyerId)) {
-            throw new BusinessException(OrderErrorCode.NOT_ORDER_OWNER);
+            throw new BusinessException(OrderErrorCode.ORDER_BUYER_MISMATCH);
         }
     }
 

--- a/src/main/java/com/pagely/marketservice/domain/model/Order.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/Order.java
@@ -108,7 +108,11 @@ public class Order extends BaseEntity {
         this.trackingNumber = trackingNumber;
         this.courierCompany = courierCompany;
         this.trackingRegisteredAt = LocalDateTime.now();
+        OrderStatus prevStatus = this.status;
         this.status = OrderStatus.SHIPPING;
+
+        // 주문 이력 생성
+        this.histories.add(OrderHistory.of(this, prevStatus, "구매 확정"));
     }
 
     // 구매 확정 (구매자)
@@ -118,10 +122,12 @@ public class Order extends BaseEntity {
             throw new BusinessException(OrderErrorCode.ORDER_STATUS_NOT_SHIPPING);
         }
 
+        OrderStatus prevStatus = this.status;
+
         // 상태변경
         this.status = OrderStatus.COMPLETED;
 
         // 주문 이력 생성
-        this.histories.add(OrderHistory.of(this, OrderStatus.SHIPPING, "구매 확정"));
+        this.histories.add(OrderHistory.of(this, prevStatus, "구매 확정"));
     }
 }

--- a/src/main/java/com/pagely/marketservice/domain/model/OrderHistory.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/OrderHistory.java
@@ -12,7 +12,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -47,4 +46,13 @@ public class OrderHistory extends BaseEntity {
     // 변경 사유
     @Column(length = 200)
     private String reason;
+
+    public static OrderHistory of(Order order, OrderStatus fromStatus, String reason) {
+        OrderHistory history = new OrderHistory();
+        history.order = order;
+        history.fromStatus = fromStatus;
+        history.toStatus = order.getStatus();
+        history.reason = reason;
+        return history;
+    }
 }

--- a/src/main/java/com/pagely/marketservice/domain/model/OrderHistory.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/OrderHistory.java
@@ -1,5 +1,6 @@
 package com.pagely.marketservice.domain.model;
 
+import com.pagely.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "p_order_history")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class OrderHistory {
+public class OrderHistory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -46,23 +47,4 @@ public class OrderHistory {
     // 변경 사유
     @Column(length = 200)
     private String reason;
-
-    // 공통 감사 컬럼
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "created_by", columnDefinition = "uuid")
-    private UUID createdBy;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    @Column(name = "updated_by", columnDefinition = "uuid")
-    private UUID updatedBy;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
-    @Column(name = "deleted_by", columnDefinition = "uuid")
-    private UUID deletedBy;
 }

--- a/src/main/java/com/pagely/marketservice/presentation/controller/OrderController.java
+++ b/src/main/java/com/pagely/marketservice/presentation/controller/OrderController.java
@@ -54,4 +54,13 @@ public class OrderController {
         OrderResult result = orderService.registerTrackingNumber(request.toCommand(sellerId, orderId));
         return ApiResponse.ok(RegisterTrackingNumberResponse.fromResult(result));
     }
+
+    @PostMapping("/{orderId}/confirm")
+    public ResponseEntity<ApiResponse> confirmOrder(
+            @RequestHeader("X-User-Id") UUID buyerId,
+            @PathVariable("orderId") UUID orderId
+    ) {
+        OrderResult result = orderService.confirmOrder(buyerId, orderId);
+        return ApiResponse.ok(OrderResponse.fromResult(result));
+    }
 }

--- a/src/main/java/com/pagely/marketservice/presentation/dto/response/CreateOrderResponse.java
+++ b/src/main/java/com/pagely/marketservice/presentation/dto/response/CreateOrderResponse.java
@@ -11,8 +11,7 @@ public record CreateOrderResponse(
         UUID salePostId,                    // 판매글 ID
         OrderStatus status,                 // 주문 상태
         int price,                          // 가격
-        LocalDateTime createdAt,            // 생성 시각
-        UUID createdBy                      // 생성자
+        LocalDateTime createdAt             // 생성 시각
 ) {
     public static CreateOrderResponse fromResult(OrderResult r) {
         return new CreateOrderResponse(
@@ -21,8 +20,7 @@ public record CreateOrderResponse(
                 r.salePostId(),
                 r.status(),
                 r.price(),
-                r.createdAt(),
-                r.createdBy()
+                r.createdAt()
         );
     }
 }

--- a/src/main/java/com/pagely/marketservice/presentation/dto/response/OrderResponse.java
+++ b/src/main/java/com/pagely/marketservice/presentation/dto/response/OrderResponse.java
@@ -15,7 +15,7 @@ public record OrderResponse(
         String courierCompany,              // 택배사
         LocalDateTime trackingRegisteredAt, // 운송장 등록 일시
         LocalDateTime createdAt,            // 생성 시각
-        UUID createdBy                      // 생성자
+        LocalDateTime updatedAt             // 수정 시각
 ) {
     public static OrderResponse fromResult(OrderResult r) {
         return new OrderResponse(
@@ -28,7 +28,7 @@ public record OrderResponse(
                 r.courierCompany(),
                 r.trackingRegisteredAt(),
                 r.createdAt(),
-                r.createdBy()
+                r.updatedAt()
         );
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 구매 확정 (구매자) API 구현

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #17 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #13   

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="823" height="531" alt="image" src="https://github.com/user-attachments/assets/1b5c0325-967a-4674-a61a-d6dff8533e18" />



## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주문 확정 API 추가 — 배송 중인 주문을 구매자가 확정할 수 있습니다.

* **개선**
  * 주문 이력 자동 기록 강화 — 운송장 등록 및 구매 확정 시 이력에 항목이 남습니다.
  * 응답 스키마 변경 — 생성자 식별자 제거 및 업데이트 시각 노출로 변경.
  * 구매자 검증 및 오류 코드·메시지 정비 — 권한·상태 검증 로직과 관련 메시지 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->