### PR TITLE
Feat/21 주문 취소 API 구현

### DIFF
--- a/src/main/java/com/pagely/marketservice/application/service/OrderService.java
+++ b/src/main/java/com/pagely/marketservice/application/service/OrderService.java
@@ -76,4 +76,22 @@ public class OrderService {
 
         return OrderResult.fromEntity(order);
     }
+
+    // 구매자 주문 취소
+    @Transactional
+    public OrderResult cancelOrder(UUID buyerId, UUID orderId) {
+        Order order = orderRepository.findByIdWithSalePost(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+        order.validateBuyer(buyerId);
+
+        boolean needsRefund = order.isAccepted();
+
+        order.cancel();
+
+        if (needsRefund) {
+            // TODO: 결제 취소 이벤트 발행
+        }
+
+        return OrderResult.fromEntity(order);
+    }
 }

--- a/src/main/java/com/pagely/marketservice/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/pagely/marketservice/domain/exception/OrderErrorCode.java
@@ -8,6 +8,7 @@ public enum OrderErrorCode implements ErrorCode {
     ORDER_SELLER_MISMATCH("해당 주문의 판매자가 아닙니다.", HttpStatus.FORBIDDEN),
     ORDER_STATUS_NOT_ACCEPTED("주문 승인 상태에서만 가능합니다.", HttpStatus.BAD_REQUEST),
     ORDER_STATUS_NOT_SHIPPING("주문 배송 상태에서만 가능합니다.", HttpStatus.BAD_REQUEST),
+    ORDER_NOT_CANCELLABLE("주문 취소가 불가능한 상태입니다.", HttpStatus.BAD_REQUEST),
     ORDER_NOT_FOUND("해당 주문을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;

--- a/src/main/java/com/pagely/marketservice/domain/exception/SalePostErrorCode.java
+++ b/src/main/java/com/pagely/marketservice/domain/exception/SalePostErrorCode.java
@@ -4,6 +4,7 @@ import com.pagely.common.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum SalePostErrorCode implements ErrorCode {
+    SALE_POST_CANNOT_RESTORE("판매글을 판매 가능 상태로 되돌릴 수 없습니다.", HttpStatus.BAD_REQUEST),
     NOT_AVAILABLE("해당 판매글은 주문이 불가능한 상태입니다.", HttpStatus.BAD_REQUEST),
     CANNOT_ORDER_OWN("본인이 등록한 판매글은 주문할 수 없습니다.", HttpStatus.BAD_REQUEST),
     INVALID_SALE_PRICE("판매 가격은 0보다 커야합니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/pagely/marketservice/domain/model/Order.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/Order.java
@@ -132,16 +132,18 @@ public class Order extends BaseEntity {
     }
 
     // 주문 취소
+    // PENDING: 결제 전 취소 → 이벤트 불필요
+    // ACCEPTED: 결제 완료 후 취소 → 결제 취소 이벤트 필요 (서비스 레이어에서 처리)
     public void cancel() {
         if (this.status != OrderStatus.PENDING && this.status != OrderStatus.ACCEPTED) {
             throw new BusinessException(OrderErrorCode.ORDER_NOT_CANCELLABLE);
         }
 
         OrderStatus prevStatus = this.status;
-        this.status = prevStatus == OrderStatus.PENDING ? OrderStatus.CANCELLED : OrderStatus.REFUND_REQUESTED;
+        this.status = OrderStatus.CANCELLED;
         this.salePost.markAvailable();
-        String reason = prevStatus == OrderStatus.PENDING ? "주문 취소" : "환불 요청";
-        this.histories.add(OrderHistory.of(this, prevStatus, reason)); // 주문 이력 생성
+        
+        this.histories.add(OrderHistory.of(this, prevStatus, "주문 취소")); // 주문 이력 생성
     }
 
     public boolean isAccepted() {

--- a/src/main/java/com/pagely/marketservice/domain/model/Order.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/Order.java
@@ -130,4 +130,21 @@ public class Order extends BaseEntity {
         // 주문 이력 생성
         this.histories.add(OrderHistory.of(this, prevStatus, "구매 확정"));
     }
+
+    // 주문 취소
+    public void cancel() {
+        if (this.status != OrderStatus.PENDING && this.status != OrderStatus.ACCEPTED) {
+            throw new BusinessException(OrderErrorCode.ORDER_NOT_CANCELLABLE);
+        }
+
+        OrderStatus prevStatus = this.status;
+        this.status = prevStatus == OrderStatus.PENDING ? OrderStatus.CANCELLED : OrderStatus.REFUND_REQUESTED;
+        this.salePost.markAvailable();
+        String reason = prevStatus == OrderStatus.PENDING ? "주문 취소" : "환불 요청";
+        this.histories.add(OrderHistory.of(this, prevStatus, reason)); // 주문 이력 생성
+    }
+
+    public boolean isAccepted() {
+        return this.status == OrderStatus.ACCEPTED;
+    }
 }

--- a/src/main/java/com/pagely/marketservice/domain/model/OrderStatus.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/OrderStatus.java
@@ -6,6 +6,5 @@ public enum OrderStatus {
     SHIPPING,
     COMPLETED,
     CANCELLED,
-    REFUND_REQUESTED,
     FAILED
 }

--- a/src/main/java/com/pagely/marketservice/domain/model/OrderStatus.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/OrderStatus.java
@@ -6,5 +6,6 @@ public enum OrderStatus {
     SHIPPING,
     COMPLETED,
     CANCELLED,
+    REFUND_REQUESTED,
     FAILED
 }

--- a/src/main/java/com/pagely/marketservice/domain/model/SalePost.java
+++ b/src/main/java/com/pagely/marketservice/domain/model/SalePost.java
@@ -99,6 +99,15 @@ public class SalePost extends BaseEntity {
         this.status = SalePostStatus.RESERVED;
     }
 
+    // 구매 가능 상태로 변경
+    public void markAvailable() {
+        if (this.status != SalePostStatus.RESERVED) {
+            throw new BusinessException(SalePostErrorCode.SALE_POST_CANNOT_RESTORE);
+        }
+
+        this.status = SalePostStatus.AVAILABLE;
+    }
+
     public boolean isSeller(UUID userId) {
         return this.sellerId.equals(userId);
     }

--- a/src/main/java/com/pagely/marketservice/presentation/controller/OrderController.java
+++ b/src/main/java/com/pagely/marketservice/presentation/controller/OrderController.java
@@ -5,6 +5,7 @@ import com.pagely.marketservice.application.dto.result.OrderResult;
 import com.pagely.marketservice.application.service.OrderService;
 import com.pagely.marketservice.presentation.dto.request.CreateOrderRequest;
 import com.pagely.marketservice.presentation.dto.request.RegisterTrackingNumberRequest;
+import com.pagely.marketservice.presentation.dto.response.CancelOrderResponse;
 import com.pagely.marketservice.presentation.dto.response.CreateOrderResponse;
 import com.pagely.marketservice.presentation.dto.response.OrderResponse;
 import com.pagely.marketservice.presentation.dto.response.RegisterTrackingNumberResponse;
@@ -62,5 +63,14 @@ public class OrderController {
     ) {
         OrderResult result = orderService.confirmOrder(buyerId, orderId);
         return ApiResponse.ok(OrderResponse.fromResult(result));
+    }
+
+    @PostMapping("/{orderId}/cancel")
+    public ResponseEntity<ApiResponse> cancelOrder(
+            @RequestHeader("X-User-Id") UUID buyerId,
+            @PathVariable("orderId") UUID orderId
+    ) {
+        OrderResult result = orderService.cancelOrder(buyerId, orderId);
+        return ApiResponse.ok(CancelOrderResponse.fromResult(result));
     }
 }

--- a/src/main/java/com/pagely/marketservice/presentation/dto/response/CancelOrderResponse.java
+++ b/src/main/java/com/pagely/marketservice/presentation/dto/response/CancelOrderResponse.java
@@ -1,0 +1,28 @@
+package com.pagely.marketservice.presentation.dto.response;
+
+import com.pagely.marketservice.application.dto.result.OrderResult;
+import com.pagely.marketservice.domain.model.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CancelOrderResponse(
+        UUID id,                            // 주문 ID
+        UUID buyerId,                       // 구매자 ID
+        UUID salePostId,                    // 판매글 ID
+        OrderStatus status,                 // 주문 상태
+        int price,                          // 가격
+        LocalDateTime createdAt,            // 생성 시각
+        LocalDateTime updatedAt             // 수정 시각
+) {
+    public static CancelOrderResponse fromResult(OrderResult r) {
+        return new CancelOrderResponse(
+                r.id(),
+                r.buyerId(),
+                r.salePostId(),
+                r.status(),
+                r.price(),
+                r.createdAt(),
+                r.updatedAt()
+        );
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 주문 취소 API 구현
- 주문 취소 이벤트 발행은 추후 구현 예정

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #21 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #13  

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="928" height="476" alt="image" src="https://github.com/user-attachments/assets/2b21d5d6-77cc-4c22-bcf2-c456f842ea56" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주문 취소 기능: 구매자는 이제 자신의 주문을 취소할 수 있습니다. 주문 상태에 따라 취소 가능 여부가 결정되며, 취소 후 판매 게시물은 다시 이용 가능하도록 복원됩니다. 필요한 경우 환불 처리가 수행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->