### PR TITLE
Feat/24 Kafka 연동 및 주문 이벤트 발행

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
+    implementation 'org.springframework.kafka:spring-kafka'
+
     implementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/com/pagely/marketservice/application/event/OrderEventHandler.java
+++ b/src/main/java/com/pagely/marketservice/application/event/OrderEventHandler.java
@@ -1,0 +1,10 @@
+package com.pagely.marketservice.application.event;
+
+import com.pagely.marketservice.domain.event.payload.OrderCancelledEvent;
+import com.pagely.marketservice.domain.event.payload.OrderCreatedEvent;
+
+public interface OrderEventHandler {
+    void handleOrderCreated(OrderCreatedEvent event);
+
+    void HandleOrderCancelled(OrderCancelledEvent event);
+}

--- a/src/main/java/com/pagely/marketservice/application/port/out/OrderEventPort.java
+++ b/src/main/java/com/pagely/marketservice/application/port/out/OrderEventPort.java
@@ -1,0 +1,10 @@
+package com.pagely.marketservice.application.port.out;
+
+import com.pagely.marketservice.domain.event.payload.OrderCancelledEvent;
+import com.pagely.marketservice.domain.event.payload.OrderCreatedEvent;
+
+public interface OrderEventPort {
+    void publishOrderCreated(OrderCreatedEvent event);
+
+    void publishOrderCancelled(OrderCancelledEvent event);
+}

--- a/src/main/java/com/pagely/marketservice/application/service/OrderService.java
+++ b/src/main/java/com/pagely/marketservice/application/service/OrderService.java
@@ -37,7 +37,6 @@ public class OrderService {
 
         Order saved = orderRepository.save(order);
 
-        //TODO: 주문 생성 완료 이벤트 발행 처리
         orderEvents.orderCreated(OrderCreatedEvent.of(saved));
 
         return OrderResult.fromEntity(saved);

--- a/src/main/java/com/pagely/marketservice/application/service/OrderService.java
+++ b/src/main/java/com/pagely/marketservice/application/service/OrderService.java
@@ -4,6 +4,9 @@ import com.pagely.common.exception.BusinessException;
 import com.pagely.marketservice.application.dto.command.CreateOrderCommand;
 import com.pagely.marketservice.application.dto.command.RegisterTrackingNumberCommand;
 import com.pagely.marketservice.application.dto.result.OrderResult;
+import com.pagely.marketservice.domain.event.OrderEvents;
+import com.pagely.marketservice.domain.event.payload.OrderCancelledEvent;
+import com.pagely.marketservice.domain.event.payload.OrderCreatedEvent;
 import com.pagely.marketservice.domain.exception.OrderErrorCode;
 import com.pagely.marketservice.domain.exception.SalePostErrorCode;
 import com.pagely.marketservice.domain.model.Order;
@@ -22,6 +25,7 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
     private final SalePostRepository salePostRepository;
+    private final OrderEvents orderEvents;
 
     @Transactional
     public OrderResult createOrder(CreateOrderCommand command) {
@@ -34,6 +38,7 @@ public class OrderService {
         Order saved = orderRepository.save(order);
 
         //TODO: 주문 생성 완료 이벤트 발행 처리
+        orderEvents.orderCreated(OrderCreatedEvent.of(saved));
 
         return OrderResult.fromEntity(saved);
     }
@@ -89,7 +94,7 @@ public class OrderService {
         order.cancel();
 
         if (needsRefund) {
-            // TODO: 결제 취소 이벤트 발행
+            orderEvents.orderCancelled(OrderCancelledEvent.of(order)); // 결제 취소 이벤트
         }
 
         return OrderResult.fromEntity(order);

--- a/src/main/java/com/pagely/marketservice/domain/event/BaseEvent.java
+++ b/src/main/java/com/pagely/marketservice/domain/event/BaseEvent.java
@@ -1,0 +1,32 @@
+package com.pagely.marketservice.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public abstract class BaseEvent {
+    private final String eventId;
+    private final String eventType;
+    private final String domainType;
+    private final String domainId;
+    private final Instant occurredAt;
+    private final Object payload;
+
+    protected BaseEvent(String domainType, UUID domainId, Object payload) {
+        this(domainType, domainId == null ? null : domainId.toString(), payload);
+    }
+
+    protected BaseEvent(String domainType, Object payload) {
+        this(domainType, (String) null, payload);
+    }
+
+    protected BaseEvent(String domainType, String domainId, Object payload) {
+        this.eventId = UUID.randomUUID().toString();
+        this.eventType = this.getClass().getSimpleName();
+        this.domainType = domainType;
+        this.domainId = domainId;
+        this.occurredAt = Instant.now();
+        this.payload = payload;
+    }
+}

--- a/src/main/java/com/pagely/marketservice/domain/event/OrderEvents.java
+++ b/src/main/java/com/pagely/marketservice/domain/event/OrderEvents.java
@@ -1,0 +1,10 @@
+package com.pagely.marketservice.domain.event;
+
+import com.pagely.marketservice.domain.event.payload.OrderCancelledEvent;
+import com.pagely.marketservice.domain.event.payload.OrderCreatedEvent;
+
+public interface OrderEvents {
+    void orderCreated(OrderCreatedEvent event);
+
+    void orderCancelled(OrderCancelledEvent event);
+}

--- a/src/main/java/com/pagely/marketservice/domain/event/payload/OrderCancelledEvent.java
+++ b/src/main/java/com/pagely/marketservice/domain/event/payload/OrderCancelledEvent.java
@@ -1,0 +1,30 @@
+package com.pagely.marketservice.domain.event.payload;
+
+import com.pagely.marketservice.domain.event.BaseEvent;
+import com.pagely.marketservice.domain.model.Order;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class OrderCancelledEvent extends BaseEvent {
+
+    private static final String DOMAIN_TYPE = "ORDER";
+
+    private OrderCancelledEvent(UUID orderId, Object payload) {
+        super(DOMAIN_TYPE, orderId, payload);
+    }
+
+    public static OrderCancelledEvent of(Order order) {
+        return new OrderCancelledEvent(
+                order.getId(),
+                new Payload(
+                        order.getId(),
+                        order.getBuyerId(),
+                        order.getPrice()
+                )
+        );
+    }
+
+    public record Payload(UUID orderId, UUID buyerId, int price) {
+    }
+}

--- a/src/main/java/com/pagely/marketservice/domain/event/payload/OrderCancelledEvent.java
+++ b/src/main/java/com/pagely/marketservice/domain/event/payload/OrderCancelledEvent.java
@@ -19,12 +19,11 @@ public class OrderCancelledEvent extends BaseEvent {
                 order.getId(),
                 new Payload(
                         order.getId(),
-                        order.getBuyerId(),
                         order.getPrice()
                 )
         );
     }
 
-    public record Payload(UUID orderId, UUID buyerId, int price) {
+    public record Payload(UUID orderId, int price) {
     }
 }

--- a/src/main/java/com/pagely/marketservice/domain/event/payload/OrderCreatedEvent.java
+++ b/src/main/java/com/pagely/marketservice/domain/event/payload/OrderCreatedEvent.java
@@ -19,11 +19,12 @@ public class OrderCreatedEvent extends BaseEvent {
                 order.getId(),
                 new Payload(
                         order.getId(),
+                        order.getBuyerId(),
                         order.getPrice()
                 )
         );
     }
 
-    public record Payload(UUID orderId, int price) {
+    public record Payload(UUID orderId, UUID buyerId, int price) {
     }
 }

--- a/src/main/java/com/pagely/marketservice/domain/event/payload/OrderCreatedEvent.java
+++ b/src/main/java/com/pagely/marketservice/domain/event/payload/OrderCreatedEvent.java
@@ -1,0 +1,29 @@
+package com.pagely.marketservice.domain.event.payload;
+
+import com.pagely.marketservice.domain.event.BaseEvent;
+import com.pagely.marketservice.domain.model.Order;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class OrderCreatedEvent extends BaseEvent {
+
+    private static final String DOMAIN_TYPE = "ORDER";
+
+    private OrderCreatedEvent(UUID orderId, Object payload) {
+        super(DOMAIN_TYPE, orderId, payload);
+    }
+
+    public static OrderCreatedEvent of(Order order) {
+        return new OrderCreatedEvent(
+                order.getId(),
+                new Payload(
+                        order.getId(),
+                        order.getPrice()
+                )
+        );
+    }
+
+    public record Payload(UUID orderId, int price) {
+    }
+}

--- a/src/main/java/com/pagely/marketservice/infrastructure/event/OrderEventHandlerAdapter.java
+++ b/src/main/java/com/pagely/marketservice/infrastructure/event/OrderEventHandlerAdapter.java
@@ -1,0 +1,29 @@
+package com.pagely.marketservice.infrastructure.event;
+
+import com.pagely.marketservice.application.event.OrderEventHandler;
+import com.pagely.marketservice.application.port.out.OrderEventPort;
+import com.pagely.marketservice.domain.event.payload.OrderCancelledEvent;
+import com.pagely.marketservice.domain.event.payload.OrderCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class OrderEventHandlerAdapter implements OrderEventHandler {
+
+    private final OrderEventPort orderEventPort;
+
+    @Override
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderCreated(OrderCreatedEvent event) {
+        orderEventPort.publishOrderCreated(event);
+    }
+
+    @Override
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void HandleOrderCancelled(OrderCancelledEvent event) {
+        orderEventPort.publishOrderCancelled(event);
+    }
+}

--- a/src/main/java/com/pagely/marketservice/infrastructure/event/SpringOrderEventPublisher.java
+++ b/src/main/java/com/pagely/marketservice/infrastructure/event/SpringOrderEventPublisher.java
@@ -1,0 +1,25 @@
+package com.pagely.marketservice.infrastructure.event;
+
+import com.pagely.marketservice.domain.event.OrderEvents;
+import com.pagely.marketservice.domain.event.payload.OrderCancelledEvent;
+import com.pagely.marketservice.domain.event.payload.OrderCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SpringOrderEventPublisher implements OrderEvents {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void orderCreated(OrderCreatedEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+
+    @Override
+    public void orderCancelled(OrderCancelledEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/src/main/java/com/pagely/marketservice/infrastructure/messaging/kafka/producer/KafkaOrderEventAdapter.java
+++ b/src/main/java/com/pagely/marketservice/infrastructure/messaging/kafka/producer/KafkaOrderEventAdapter.java
@@ -3,15 +3,40 @@ package com.pagely.marketservice.infrastructure.messaging.kafka.producer;
 import com.pagely.marketservice.application.port.out.OrderEventPort;
 import com.pagely.marketservice.domain.event.payload.OrderCancelledEvent;
 import com.pagely.marketservice.domain.event.payload.OrderCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
 
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class KafkaOrderEventAdapter implements OrderEventPort {
+
+    private static final String ORDER_CREATED_TOPIC = "order.created";
+    private static final String ORDER_CANCELLED_TOPIC = "order.cancelled";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
     @Override
     public void publishOrderCreated(OrderCreatedEvent event) {
-        
+        publish(ORDER_CREATED_TOPIC, event.getDomainId(), event);
     }
 
     @Override
     public void publishOrderCancelled(OrderCancelledEvent event) {
+        publish(ORDER_CANCELLED_TOPIC, event.getDomainId(), event);
+    }
 
+    private void publish(String topic, String key, Object event) {
+        kafkaTemplate.send(topic, key, event)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Kafka 발생 실패 topic: {} key: {}", topic, key);
+                    } else {
+                        log.info("Kafka 발행 성공 topic: {} key: {} offset: {}",
+                                topic, key, result.getRecordMetadata().offset());
+                    }
+                });
     }
 }

--- a/src/main/java/com/pagely/marketservice/infrastructure/messaging/kafka/producer/KafkaOrderEventAdapter.java
+++ b/src/main/java/com/pagely/marketservice/infrastructure/messaging/kafka/producer/KafkaOrderEventAdapter.java
@@ -13,8 +13,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class KafkaOrderEventAdapter implements OrderEventPort {
 
-    private static final String ORDER_CREATED_TOPIC = "order.created";
-    private static final String ORDER_CANCELLED_TOPIC = "order.cancelled";
+    private static final String ORDER_CREATED_TOPIC = "order-created";
+    private static final String ORDER_CANCELLED_TOPIC = "order-cancelled";
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
 

--- a/src/main/java/com/pagely/marketservice/infrastructure/messaging/kafka/producer/KafkaOrderEventAdapter.java
+++ b/src/main/java/com/pagely/marketservice/infrastructure/messaging/kafka/producer/KafkaOrderEventAdapter.java
@@ -1,0 +1,17 @@
+package com.pagely.marketservice.infrastructure.messaging.kafka.producer;
+
+import com.pagely.marketservice.application.port.out.OrderEventPort;
+import com.pagely.marketservice.domain.event.payload.OrderCancelledEvent;
+import com.pagely.marketservice.domain.event.payload.OrderCreatedEvent;
+
+public class KafkaOrderEventAdapter implements OrderEventPort {
+    @Override
+    public void publishOrderCreated(OrderCreatedEvent event) {
+        
+    }
+
+    @Override
+    public void publishOrderCancelled(OrderCancelledEvent event) {
+
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,7 +32,7 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
-        spring.json.add.type.headers: true
+        spring.json.add.type.headers: false
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,9 +26,20 @@ spring:
     locations: classpath:db/migration
     baseline-on-migrate: true
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: true
+
 logging:
   level:
     org.flywaydb: info
+    com.pagely.marketservice: debug
+    org.springframework.kafka: info
+    org.apache.kafka.clients.producer: info
 
 eureka:
   client:


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- #24 
- Kafka 연동 및 주문 이벤트 발행
- 주문 생성 이벤트
  - Topic : `order-created`
- 주문 취소 이벤트
  - Topic : `order-cancelled`
  
## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #24
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 24

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
- 주문 생성 API
<img width="923" height="439" alt="image" src="https://github.com/user-attachments/assets/b15ade52-fab9-44c3-92da-36382e1c1fa1" />

- 주문 생성 MESSAGE
<img width="1289" height="746" alt="image" src="https://github.com/user-attachments/assets/782261ce-15ec-47a3-996f-bc5352ca3216" />
 
- 주문 취소 API
<img width="924" height="448" alt="image" src="https://github.com/user-attachments/assets/e0d39f68-2b9f-47c8-93c6-d162c7f6e684" />

- 주문 취소 MESSAGE
<img width="1291" height="728" alt="image" src="https://github.com/user-attachments/assets/e0168398-0581-415a-8816-ea231d05a8bc" />

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주문 생성/취소 이벤트 발행 및 처리 기능 추가
  * 이벤트 기반 퍼블리셔와 어댑터로 주문 이벤트를 애플리케이션 이벤트 버스로 전파
  * Kafka 프로듀서 연동으로 주문 이벤트를 외부 Kafka 토픽으로 전송 가능
  * 트랜잭션 커밋 후 이벤트 전파 보장 및 전송 상태 로깅 강화
  * Kafka 및 로깅 설정 추가로 운영 가시성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->